### PR TITLE
Enable installation in Visual Studio 2015 and higher

### DIFF
--- a/src/source.extension.vsixmanifest
+++ b/src/source.extension.vsixmanifest
@@ -11,6 +11,7 @@
     </Metadata>
     <Installation InstalledByMsi="false">
         <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="12.0" />
+        <InstallationTarget Version="[14.0,)" Id="Microsoft.VisualStudio.Community" />
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />


### PR DESCRIPTION
Did you remove VS 2015 support in 4599a7f40ae0214f88fff87dda438e478e5e0d13 intentionally? This allows to install the Extension in VS 2015 and higher (not sure if you want that). It is also for the Community Version and (I believe) higher SKUs.

The extension worked just fine for the last few days in VS 2015 Community. I don't know how I can check whether an extension was successfully auto updated or not.

BTW: I love your extensions.